### PR TITLE
MongoDB→PostgreSQL 파이프라인 구현

### DIFF
--- a/etl-service/Dockerfile
+++ b/etl-service/Dockerfile
@@ -1,0 +1,45 @@
+> docker version
+
+> mkdir mongo-data
+
+## 도커 몽고디비 세팅
+> docker run -d --name my-mongo -p 27017:27017 -v %cd%\mongo-data:/data/db -e MONGO_INITDB_ROOT_USERNAME=admin -e MONGO_INITDB_ROOT_PASSWORD=secret123 mongo:latest
+
+> docker ps ( up 확인 )
+
+## 도커 몽고디비 접속
+> docker exec -it my-mongo mongosh -u admin -p secret123 --authenticationDatabase admin
+
+# use DATABASE_NAME
+
+# db.createUser({user:"testuser1", pwd:"1234", roles:[{role:"readWrite",db:"jobdata"}]})
+
+# exit
+
+## ETL 세팅
+> mkdir etl-project ( ETL용 서브 디렉터리 )
+
+> cd etl-project
+
+## 파이썬 가상환경 세팅 ( Power Shell )
+> python -m venv .venv
+
+> .\.venv\Scripts\Activate.ps1
+
+(.venv) > python -m pip install --upgrade pip
+(.venv) > python -m pip install pandas pymongo sqlalchemy psycopg2-binary python-dotenv
+
+## etl-project 파일에서 .env파일 생성 후 아래 작성
+# MongoDB 접속 정보
+MONGO_URI=mongodb://jobuser:jobpass@localhost:27017/jobdata
+
+# PostgreSQL 접속 정보
+POSTGRES_URI=postgresql+psycopg2://pguser:pgpass@localhost:5432/jobdb
+
+docker exec -it my-postgres psql -U pguser -d jobdb
+
+
+
+
+
+

--- a/etl-service/etl-project/README.md
+++ b/etl-service/etl-project/README.md
@@ -1,0 +1,108 @@
+# 목차
+1. 설치 및 준비
+2. Docker 환경 가이드 및 예제 코드
+
+### 주요 파일  
+- `.env`           — 환경변수 정의  
+- `docker-compose.yml` — MongoDB·PostgreSQL 서비스 정의  
+- `requirements.txt`  — 파이썬 라이브러리 목록  
+- `etl.py`         — MongoDB → PostgreSQL ETL 스크립트  
+
+## 1. 설치 및 준비
+
+1. 저장소 클론  
+   bash
+   git clone https://github.com/your-org/datajob-insight.git
+   cd datajob-insight/etl-service/etl-project
+
+2. 환경변수 파일 생성
+프로젝트 루트에 .env 파일을 만들고 아래 작성
+#####
+PGOPTIONS=-c client_encoding=UTF8 -c lc_messages=C
+
+MONGO_URI=mongodb://root:example_pw@localhost:27017/jobdata?authSource=admin
+MONGO_DB=jobdata
+
+POSTGRES_SERVER=localhost
+POSTGRES_USER=datajob_user
+POSTGRES_PASSWORD=1234
+POSTGRES_DB=datajob_test
+POSTGRES_PORT=5432
+
+PGCLIENTENCODING=UTF8
+#####
+
+3. 파이썬 의존성 설치
+pip install --no-cache-dir -r requirements.txt
+
+4. Docker 컨테이너 실행
+docker-compose up -d
+
+### 사용법
+1. ETL 스크립트 실행
+python etl.py
+
+* .env 로드 → MongoDB에서 데이터 조회 → PostgreSQL에 upsert
+* 콘솔에 삽입/업데이트 건수가 로그로 출력됩니다.
+
+2. Docker Compose 명령어
+* 로그 보기
+docker-compose logs mongo_db
+docker-compose logs postgres_db
+* 서비스 중지 및 볼륨 삭제
+docker-compose down -v
+
+## 2. Docker 환경 가이드 및 예제 코드
+* docker-compose.yml
+version: "3.8"
+
+services:
+  mongo_db:
+    image: mongo:6.0
+    container_name: mongo_db
+    restart: always
+    environment:
+      MONGO_INITDB_ROOT_USERNAME: root
+      MONGO_INITDB_ROOT_PASSWORD: example_pw
+    ports:
+      - "27017:27017"
+
+  postgres_db:
+    image: postgres:14
+    container_name: postgres_db
+    restart: always
+    environment:
+      POSTGRES_USER: ${POSTGRES_USER}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
+      POSTGRES_DB: ${POSTGRES_DB}
+    ports:
+      - "5432:5432"
+
+volumes:
+  pgdata:
+
+* 설명
+1. MongoDB
+* mongo_db:27017 포트 매핑
+* 루트 사용자 및 비밀번호 설정
+
+2. PostgreSQL
+* postgres_db:5432 포트 매핑
+* ${POSTGRES_*} 환경변수를 통해 유연하게 설정
+
+3. 볼륨
+* pgdata 로 Postgres 데이터 영속화
+
+## 3. 환경변수 설정 및 구성 옵션 설명
+| 변수 이름               | 예시 값                                                                 | 설명                                          |
+| ------------------- | -------------------------------------------------------------------- | ------------------------------------------- |
+| `PGOPTIONS`         | `-c client_encoding=UTF8 -c lc_messages=C`                           | psycopg2의 클라이언트 인코딩·메시지 로케일 강제 설정           |
+| `MONGO_URI`         | `mongodb://root:example_pw@localhost:27017/jobdata?authSource=admin` | MongoDB 연결 문자열 (사용자, 비밀번호, 호스트, DB 지정)      |
+| `MONGO_DB`          | `jobdata`                                                            | MongoDB 내에서 사용할 데이터베이스 이름                   |
+| `POSTGRES_SERVER`   | `localhost`                                                          | PostgreSQL 호스트 (컨테이너 내부 실행 시 `postgres_db`) |
+| `POSTGRES_PORT`     | `5432`                                                               | PostgreSQL 포트                               |
+| `POSTGRES_DB`       | `datajob_test`                                                       | PostgreSQL 데이터베이스 이름                        |
+| `POSTGRES_USER`     | `datajob_user`                                                       | PostgreSQL 사용자명                             |
+| `POSTGRES_PASSWORD` | `1234`                                                               | PostgreSQL 사용자 비밀번호                         |
+| `PGCLIENTENCODING`  | `UTF8`                                                               | psycopg2 연결 시 사용할 문자 인코딩                    |
+| `PGPASSFILE`        | `./.pgpass`                                                          | libpq가 참조하는 비밀번호 파일 경로 (일반적으로 제거 권장)        |

--- a/etl-service/etl-project/dags/etl_dag.py
+++ b/etl-service/etl-project/dags/etl_dag.py
@@ -1,0 +1,25 @@
+from airflow import DAG
+from airflow.operators.bash import BashOperator
+from datetime import datetime, timedelta
+
+default_args = {
+    'owner': 'you',
+    'depends_on_past': False,
+    'email_on_failure': False,
+    'retries': 1,
+    'retry_delay': timedelta(minutes=5),
+}
+
+with DAG(
+    'daily_etl',
+    default_args=default_args,
+    description='Daily ETL from MongoDB to Postgres',
+    schedule_interval='0 3 * * *',  # 매일 새벽 3시
+    start_date=datetime(2025, 6, 20),
+    catchup=False,
+) as dag:
+
+    run_etl = BashOperator(
+        task_id='run_etl_script',
+        bash_command='cd /app && pip install -r requirements.txt && python etl.py',
+    )

--- a/etl-service/etl-project/docker-compose.yml
+++ b/etl-service/etl-project/docker-compose.yml
@@ -1,0 +1,71 @@
+version: "3.8"
+
+services:
+  mongo_db:
+    image: mongo:6.0
+    container_name: mongo_db
+    restart: always
+    environment:
+      MONGO_INITDB_ROOT_USERNAME: root
+      MONGO_INITDB_ROOT_PASSWORD: example_pw
+    ports:
+      - "27017:27017"
+
+  postgres_db:
+    image: postgres:14
+    container_name: postgres_db
+    restart: always
+    environment:
+      POSTGRES_USER: pguser
+      POSTGRES_PASSWORD: pgpass
+      POSTGRES_DB: jobdb
+    ports:
+      - "5432:5432"
+    volumes:
+      - pgdata:/var/lib/postgresql/data
+
+  etl:
+    image: python:3.9-slim
+    container_name: etl_service
+    working_dir: /app
+    volumes:
+      - ./:/app
+    env_file:
+      - ./.env
+    # 여기서 pip install 후 etl.py 실행
+    command: bash -c "pip install --no-cache-dir -r requirements.txt && python etl.py"
+    depends_on:
+      - mongo_db
+      - postgres_db
+
+
+  ############################### Airflow services ###############################
+  # airflow-webserver:
+  #   image: apache/airflow:2.8.1
+  #   restart: always
+  #   depends_on:
+  #     - postgres_db
+  #   environment:
+  #     AIRFLOW__CORE__LOAD_EXAMPLES: "false"
+  #     AIRFLOW__CORE__EXECUTOR: LocalExecutor
+  #     AIRFLOW__CORE__SQL_ALCHEMY_CONN: postgresql+psycopg2://pguser:pgpass@postgres_db/jobdb
+  #     AIRFLOW__CORE__FERNET_KEY: "$(openssl rand -base64 32)"
+  #   volumes:
+  #     - ./dags:/opt/airflow/dags
+  #   ports:
+  #     - "8080:8080"
+  #   command: webserver
+
+  # airflow-scheduler:
+  #   image: apache/airflow:2.8.1
+  #   restart: always
+  #   depends_on:
+  #     - airflow-webserver
+  #   environment:
+  #     AIRFLOW__CORE__SQL_ALCHEMY_CONN: postgresql+psycopg2://pguser:pgpass@postgres_db/jobdb
+  #   volumes:
+  #     - ./dags:/opt/airflow/dags
+  #   command: scheduler
+
+volumes:
+  pgdata:

--- a/etl-service/etl-project/docker-compose.yml
+++ b/etl-service/etl-project/docker-compose.yml
@@ -12,13 +12,15 @@ services:
       - "27017:27017"
 
   postgres_db:
-    image: postgres:14
+    image: postgres:15
     container_name: postgres_db
     restart: always
+    env_file:
+      - ./.env
     environment:
-      POSTGRES_USER: pguser
-      POSTGRES_PASSWORD: pgpass
-      POSTGRES_DB: jobdb
+      POSTGRES_USER: ${POSTGRES_USER}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
+      POSTGRES_DB: ${POSTGRES_DB}
     ports:
       - "5432:5432"
     volumes:

--- a/etl-service/etl-project/etl.py
+++ b/etl-service/etl-project/etl.py
@@ -1,0 +1,224 @@
+import os
+import logging
+from datetime import datetime
+from dotenv import load_dotenv
+from pymongo import MongoClient
+import psycopg2
+
+# 환경변수 로드
+load_dotenv()
+
+# 로깅 설정
+logging.basicConfig(level=logging.INFO, format='%(asctime)s %(levelname)s %(message)s')
+logger = logging.getLogger(__name__)
+
+# MongoDB 연결
+mongo = MongoClient(os.getenv("MONGO_URI"))
+mdb = mongo[os.getenv("MONGO_DB")]
+
+# PostgreSQL 연결
+pg_conn = psycopg2.connect(
+    dbname=os.getenv("PG_DB"),
+    user=os.getenv("PG_USER"),
+    password=os.getenv("PG_PASS"),
+    host=os.getenv("PG_HOST"),
+    port=os.getenv("PG_PORT")
+)
+pg_cur = pg_conn.cursor()
+
+# DDL 생성
+ddl_statements = [
+    """
+    CREATE TABLE IF NOT EXISTS platform (
+        platform_id SERIAL PRIMARY KEY,
+        platform_name VARCHAR(50) UNIQUE
+    )
+    """,
+    """
+    CREATE TABLE IF NOT EXISTS company (
+        company_id SERIAL PRIMARY KEY,
+        name VARCHAR(100) UNIQUE,
+        size VARCHAR(20),
+        industry VARCHAR(100),
+        description TEXT,
+        sales VARCHAR(50)
+    )
+    """,
+    """
+    CREATE TABLE IF NOT EXISTS job_postings (
+        posting_id BIGSERIAL PRIMARY KEY,
+        platform_id INT REFERENCES platform(platform_id),
+        company_id INT REFERENCES company(company_id),
+        job_id VARCHAR(50) UNIQUE,
+        title VARCHAR(200),
+        job_type VARCHAR(50),
+        location VARCHAR(100),
+        experience_min INT,
+        experience_max INT,
+        education VARCHAR(20),
+        url VARCHAR(500),
+        crawled_at TIMESTAMP
+    )
+    """,
+    """
+    CREATE TABLE IF NOT EXISTS skill (
+        skill_id SERIAL PRIMARY KEY,
+        name VARCHAR(50) UNIQUE
+    )
+    """,
+    """
+    CREATE TABLE IF NOT EXISTS job_posting_skill (
+        posting_id BIGINT REFERENCES job_postings(posting_id),
+        company_id INT REFERENCES company(company_id),
+        skill_id INT REFERENCES skill(skill_id),
+        platform_id INT REFERENCES platform(platform_id),
+        PRIMARY KEY (posting_id, skill_id)
+    )
+    """,
+    """
+    CREATE TABLE IF NOT EXISTS log (
+        log_id SERIAL PRIMARY KEY,
+        log_data TEXT,
+        log_date TIMESTAMP DEFAULT NOW()
+    )
+    """
+]
+
+for stmt in ddl_statements:
+    pg_cur.execute(stmt)
+pg_conn.commit()
+
+def upsert_platform(name):
+    pg_cur.execute(
+        "INSERT INTO platform (platform_name) VALUES (%s) ON CONFLICT DO NOTHING",
+        (name,)
+    )
+    pg_cur.execute("SELECT platform_id FROM platform WHERE platform_name = %s", (name,))
+    return pg_cur.fetchone()[0]
+
+def upsert_company(info):
+    pg_cur.execute(
+        """
+        INSERT INTO company (name, size, industry, description, sales)
+        VALUES (%s, %s, %s, %s, %s)
+        ON CONFLICT (name) DO UPDATE
+          SET size = EXCLUDED.size,
+              industry = EXCLUDED.industry,
+              description = EXCLUDED.description,
+              sales = EXCLUDED.sales
+        """,
+        (info.get("name"), info.get("size"), info.get("industry"),
+         info.get("description"), info.get("sales"))
+    )
+    pg_cur.execute("SELECT company_id FROM company WHERE name = %s", (info.get("name"),))
+    return pg_cur.fetchone()[0]
+
+def upsert_skill(name):
+    pg_cur.execute(
+        "INSERT INTO skill (name) VALUES (%s) ON CONFLICT DO NOTHING",
+        (name,)
+    )
+    pg_cur.execute("SELECT skill_id FROM skill WHERE name = %s", (name,))
+    return pg_cur.fetchone()[0]
+
+def log_error(message):
+    pg_cur.execute(
+        "INSERT INTO log (log_data) VALUES (%s)",
+        (message,)
+    )
+    pg_conn.commit()
+
+def process_document(doc):
+    try:
+        platform_id = upsert_platform(doc["platform"])
+        company_id = upsert_company(doc["company"])
+
+        # 경력 정보 파싱 및 정수 변환
+        exp = doc.get("experience", {})
+        raw_min = exp.get("min_years", 0)
+        raw_max = exp.get("max_years", 0)
+        try:
+            min_years = int(raw_min)
+        except (TypeError, ValueError):
+            min_years = 0
+        try:
+            max_years = int(raw_max)
+        except (TypeError, ValueError):
+            max_years = min_years
+
+        # 위치 문자열 조합
+        loc = doc.get("location", {})
+        location_str = loc.get("city", "")
+        if loc.get("district"):
+            location_str += " " + loc["district"]
+
+        # crawled_at 처리
+        raw_crawled = doc.get("crawled_at")
+        if isinstance(raw_crawled, dict) and "$date" in raw_crawled:
+            crawled_at = datetime.fromisoformat(raw_crawled["$date"].replace("Z", "+00:00"))
+        elif isinstance(raw_crawled, str):
+            crawled_at = datetime.fromisoformat(raw_crawled.replace("Z", "+00:00"))
+        else:
+            crawled_at = raw_crawled  # 이미 datetime 객체인 경우
+
+        # 공고 삽입
+        pg_cur.execute(
+            """
+            INSERT INTO job_postings
+            (platform_id, company_id, job_id, title, job_type, location,
+             experience_min, experience_max, education, url, crawled_at)
+            VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
+            ON CONFLICT (job_id) DO NOTHING
+            RETURNING posting_id
+            """,
+            (
+                platform_id,
+                company_id,
+                doc.get("job_id"),
+                doc.get("job_title"),
+                doc.get("work_type"),
+                location_str,
+                min_years,
+                max_years,
+                doc.get("education"),
+                doc.get("job_url"),
+                crawled_at
+            )
+        )
+        result = pg_cur.fetchone()
+        if result:
+            posting_id = result[0]
+        else:
+            pg_cur.execute("SELECT posting_id FROM job_postings WHERE job_id = %s", (doc.get("job_id"),))
+            posting_id = pg_cur.fetchone()[0]
+
+        # 기술 스택 삽입
+        for skill_name in doc.get("tech_stack", {}).get("raw_list", []):
+            skill_id = upsert_skill(skill_name)
+            pg_cur.execute(
+                """
+                INSERT INTO job_posting_skill
+                (posting_id, company_id, skill_id, platform_id)
+                VALUES (%s, %s, %s, %s)
+                ON CONFLICT DO NOTHING
+                """,
+                (posting_id, company_id, skill_id, platform_id)
+            )
+
+        pg_conn.commit()
+        logger.info(f"Processed job_id={doc.get('job_id')} posting_id={posting_id}")
+
+    except Exception as e:
+        pg_conn.rollback()
+        error_msg = f"Error processing job_id={doc.get('job_id')}: {e}"
+        logger.error(error_msg)
+        log_error(error_msg)
+
+def run_etl():
+    for doc in mdb.job_postings.find({}):
+        process_document(doc)
+
+if __name__ == "__main__":
+    run_etl()
+    pg_cur.close()
+    pg_conn.close()

--- a/etl-service/etl-project/etl.py
+++ b/etl-service/etl-project/etl.py
@@ -7,77 +7,135 @@ import psycopg2
 
 # 환경변수 로드
 load_dotenv()
+os.environ.pop('PGPASSFILE', None)
 
 # 로깅 설정
 logging.basicConfig(level=logging.INFO, format='%(asctime)s %(levelname)s %(message)s')
 logger = logging.getLogger(__name__)
 
+# 환경변수 출력 (디버깅용)
+print("'POSTGRES_SERVER' →", repr(os.getenv("POSTGRES_SERVER")))
+print("'POSTGRES_PORT'   →", repr(os.getenv("POSTGRES_PORT")))
+print("'POSTGRES_DB'     →", repr(os.getenv("POSTGRES_DB")))
+print("'POSTGRES_USER'   →", repr(os.getenv("POSTGRES_USER")))
+print("'POSTGRES_PASSWORD'→", repr(os.getenv("POSTGRES_PASSWORD")))
+
 # MongoDB 연결
 mongo = MongoClient(os.getenv("MONGO_URI"))
 mdb = mongo[os.getenv("MONGO_DB")]
 
-# PostgreSQL 연결
+# PostgreSQL 연결 (client_encoding=UTF8, lc_messages=C 강제)
+print("'POSTGRES_PASSWORD'→", repr(os.getenv("POSTGRES_PASSWORD")))
 pg_conn = psycopg2.connect(
-    dbname=os.getenv("PG_DB"),
-    user=os.getenv("PG_USER"),
-    password=os.getenv("PG_PASS"),
-    host=os.getenv("PG_HOST"),
-    port=os.getenv("PG_PORT")
+    host=os.getenv('POSTGRES_SERVER'),
+    port=os.getenv('POSTGRES_PORT'),
+    dbname=os.getenv('POSTGRES_DB'),
+    user=os.getenv('POSTGRES_USER'),
+    password=os.getenv('POSTGRES_PASSWORD'),
+    client_encoding=os.getenv('PGCLIENTENCODING', 'UTF8')
 )
 pg_cur = pg_conn.cursor()
 
-# DDL 생성
+# --------------------------------------------------
+# 1) DDL 생성 (없으면 테이블 만들기)
+# --------------------------------------------------
 ddl_statements = [
     """
     CREATE TABLE IF NOT EXISTS platform (
-        platform_id SERIAL PRIMARY KEY,
+        platform_id   SERIAL PRIMARY KEY,
         platform_name VARCHAR(50) UNIQUE
     )
     """,
     """
     CREATE TABLE IF NOT EXISTS company (
-        company_id SERIAL PRIMARY KEY,
-        name VARCHAR(100) UNIQUE,
-        size VARCHAR(20),
-        industry VARCHAR(100),
-        description TEXT,
-        sales VARCHAR(50)
+        company_id      SERIAL PRIMARY KEY,
+        name            VARCHAR(100) UNIQUE,
+        size            VARCHAR(20),
+        industry        VARCHAR(100),
+        description     TEXT,
+        sales           VARCHAR(50)
     )
     """,
     """
     CREATE TABLE IF NOT EXISTS job_postings (
-        posting_id BIGSERIAL PRIMARY KEY,
-        platform_id INT REFERENCES platform(platform_id),
-        company_id INT REFERENCES company(company_id),
-        job_id VARCHAR(50) UNIQUE,
-        title VARCHAR(200),
-        job_type VARCHAR(50),
-        location VARCHAR(100),
-        experience_min INT,
-        experience_max INT,
-        education VARCHAR(20),
-        url VARCHAR(500),
-        crawled_at TIMESTAMP
+        posting_id   BIGSERIAL PRIMARY KEY,
+        platform_id  INT      REFERENCES platform(platform_id),
+        company_id   INT      REFERENCES company(company_id),
+        job_id       VARCHAR(50) UNIQUE,
+        title        VARCHAR(200),
+        job_type     VARCHAR(50),
+        raw_text     VARCHAR(200),
+        min_years    INT,
+        max_years    INT,
+        education    VARCHAR(20),
+        tech_stack   VARCHAR(200),
+        data_role    BOOLEAN,
+        url          VARCHAR(500),
+        apply_end    VARCHAR(10),
+        crawled_at   TIMESTAMP
     )
     """,
     """
     CREATE TABLE IF NOT EXISTS skill (
         skill_id SERIAL PRIMARY KEY,
-        name VARCHAR(50) UNIQUE
+        name     VARCHAR(50) UNIQUE
     )
     """,
     """
     CREATE TABLE IF NOT EXISTS job_posting_skill (
-        posting_id BIGINT REFERENCES job_postings(posting_id),
-        company_id INT REFERENCES company(company_id),
-        skill_id INT REFERENCES skill(skill_id),
-        platform_id INT REFERENCES platform(platform_id),
+        posting_id BIGINT    REFERENCES job_postings(posting_id),
+        skill_id   INT       REFERENCES skill(skill_id),
+        skill_type VARCHAR(20),
         PRIMARY KEY (posting_id, skill_id)
     )
     """,
     """
+    CREATE TABLE IF NOT EXISTS location (
+        location_id    SERIAL PRIMARY KEY,
+        city           VARCHAR(50),
+        district       VARCHAR(50),
+        detail_address VARCHAR(200),
+        posting_id     BIGINT REFERENCES job_postings(posting_id)
+    )
+    """,
+    """
+    CREATE TABLE IF NOT EXISTS experience (
+        exp_id     SERIAL PRIMARY KEY,
+        posting_id BIGINT NOT NULL REFERENCES job_postings(posting_id),
+        raw_text   VARCHAR(50),
+        min_years  INT,
+        max_years  INT
+    )
+    """,
+    """
+    CREATE TABLE IF NOT EXISTS position (
+        pos_id     SERIAL PRIMARY KEY,
+        posting_id BIGINT NOT NULL REFERENCES job_postings(posting_id),
+        raw_text   VARCHAR(200)
+    )
+    """,
+    """
+    CREATE TABLE IF NOT EXISTS position_list (
+        id     SERIAL PRIMARY KEY,
+        pos_id INT    REFERENCES position(pos_id),
+        role   VARCHAR(50)
+    )
+    """,
+    """
+    CREATE TABLE IF NOT EXISTS position_normalized (
+        norm_id            SERIAL PRIMARY KEY,
+        pos_id             INT     REFERENCES position(pos_id),
+        primary_category   VARCHAR(50),
+        secondary_category VARCHAR(50),
+        primary_label      VARCHAR(50),
+        secondary_label    VARCHAR(50),
+        confidence         VARCHAR(20),
+        is_data_role       BOOLEAN
+    )
+    """,
+    """
     CREATE TABLE IF NOT EXISTS log (
-        log_id SERIAL PRIMARY KEY,
+        log_id   SERIAL PRIMARY KEY,
         log_data TEXT,
         log_date TIMESTAMP DEFAULT NOW()
     )
@@ -88,6 +146,9 @@ for stmt in ddl_statements:
     pg_cur.execute(stmt)
 pg_conn.commit()
 
+# --------------------------------------------------
+# 2) Upsert 헬퍼 함수
+# --------------------------------------------------
 def upsert_platform(name):
     pg_cur.execute(
         "INSERT INTO platform (platform_name) VALUES (%s) ON CONFLICT DO NOTHING",
@@ -102,13 +163,19 @@ def upsert_company(info):
         INSERT INTO company (name, size, industry, description, sales)
         VALUES (%s, %s, %s, %s, %s)
         ON CONFLICT (name) DO UPDATE
-          SET size = EXCLUDED.size,
-              industry = EXCLUDED.industry,
-              description = EXCLUDED.description,
-              sales = EXCLUDED.sales
+          SET
+            size        = EXCLUDED.size,
+            industry    = COALESCE(EXCLUDED.industry,    company.industry),
+            description = COALESCE(EXCLUDED.description, company.description),
+            sales       = COALESCE(EXCLUDED.sales,       company.sales)
         """,
-        (info.get("name"), info.get("size"), info.get("industry"),
-         info.get("description"), info.get("sales"))
+        (
+            info.get("name"),
+            info.get("size"),
+            info.get("industry"),
+            info.get("description"),
+            info.get("sales"),
+        )
     )
     pg_cur.execute("SELECT company_id FROM company WHERE name = %s", (info.get("name"),))
     return pg_cur.fetchone()[0]
@@ -128,46 +195,36 @@ def log_error(message):
     )
     pg_conn.commit()
 
+# --------------------------------------------------
+# 3) 문서 처리 함수
+# --------------------------------------------------
 def process_document(doc):
     try:
         platform_id = upsert_platform(doc["platform"])
-        company_id = upsert_company(doc["company"])
+        company_id  = upsert_company(doc["company"])
 
-        # 경력 정보 파싱 및 정수 변환
+        # 경력 파싱
         exp = doc.get("experience", {})
-        raw_min = exp.get("min_years", 0)
-        raw_max = exp.get("max_years", 0)
-        try:
-            min_years = int(raw_min)
-        except (TypeError, ValueError):
-            min_years = 0
-        try:
-            max_years = int(raw_max)
-        except (TypeError, ValueError):
-            max_years = min_years
+        try: min_years = int(exp.get("min_years", 0))
+        except: min_years = None
+        try: max_years = int(exp.get("max_years", 0))
+        except: max_years = None
 
-        # 위치 문자열 조합
-        loc = doc.get("location", {})
-        location_str = loc.get("city", "")
-        if loc.get("district"):
-            location_str += " " + loc["district"]
-
-        # crawled_at 처리
+        # crawled_at 파싱
         raw_crawled = doc.get("crawled_at")
         if isinstance(raw_crawled, dict) and "$date" in raw_crawled:
             crawled_at = datetime.fromisoformat(raw_crawled["$date"].replace("Z", "+00:00"))
-        elif isinstance(raw_crawled, str):
-            crawled_at = datetime.fromisoformat(raw_crawled.replace("Z", "+00:00"))
         else:
-            crawled_at = raw_crawled  # 이미 datetime 객체인 경우
+            crawled_at = None
 
-        # 공고 삽입
+        # job_postings 삽입
         pg_cur.execute(
             """
             INSERT INTO job_postings
-            (platform_id, company_id, job_id, title, job_type, location,
-             experience_min, experience_max, education, url, crawled_at)
-            VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
+              (platform_id, company_id, job_id, title, job_type,
+               raw_text, min_years, max_years, education, tech_stack,
+               data_role, url, apply_end, crawled_at)
+            VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
             ON CONFLICT (job_id) DO NOTHING
             RETURNING posting_id
             """,
@@ -177,43 +234,95 @@ def process_document(doc):
                 doc.get("job_id"),
                 doc.get("job_title"),
                 doc.get("work_type"),
-                location_str,
+                doc["position"].get("raw_text"),
                 min_years,
                 max_years,
                 doc.get("education"),
+                ",".join(doc.get("tech_stack", {}).get("raw_list", [])),
+                doc["position"]["normalized"].get("is_data_role", False),
                 doc.get("job_url"),
+                doc.get("apply_end"),
                 crawled_at
             )
         )
-        result = pg_cur.fetchone()
-        if result:
-            posting_id = result[0]
+        row = pg_cur.fetchone()
+        if row:
+            posting_id = row[0]
         else:
             pg_cur.execute("SELECT posting_id FROM job_postings WHERE job_id = %s", (doc.get("job_id"),))
             posting_id = pg_cur.fetchone()[0]
 
-        # 기술 스택 삽입
-        for skill_name in doc.get("tech_stack", {}).get("raw_list", []):
-            skill_id = upsert_skill(skill_name)
+        # location 삽입
+        loc = doc.get("location", {})
+        pg_cur.execute(
+            "INSERT INTO location (city, district, detail_address, posting_id) VALUES (%s, %s, %s, %s)",
+            (loc.get("city"), loc.get("district"), loc.get("detail_address"), posting_id)
+        )
+
+        # experience 삽입
+        pg_cur.execute(
+            "INSERT INTO experience (posting_id, raw_text, min_years, max_years) VALUES (%s, %s, %s, %s)",
+            (posting_id, exp.get("raw_text"), min_years, max_years)
+        )
+
+        # position/position_list/position_normalized 삽입
+        pg_cur.execute(
+            "INSERT INTO position (posting_id, raw_text) VALUES (%s, %s) RETURNING pos_id",
+            (posting_id, doc["position"].get("raw_text"))
+        )
+        pos_id = pg_cur.fetchone()[0]
+
+        for role in doc["position"].get("raw_list", []):
             pg_cur.execute(
-                """
-                INSERT INTO job_posting_skill
-                (posting_id, company_id, skill_id, platform_id)
-                VALUES (%s, %s, %s, %s)
-                ON CONFLICT DO NOTHING
-                """,
-                (posting_id, company_id, skill_id, platform_id)
+                "INSERT INTO position_list (pos_id, role) VALUES (%s, %s)",
+                (pos_id, role)
+            )
+
+        norm = doc["position"].get("normalized", {})
+        pg_cur.execute(
+            """
+            INSERT INTO position_normalized
+              (pos_id, primary_category, secondary_category,
+               primary_label, secondary_label, confidence, is_data_role)
+            VALUES (%s, %s, %s, %s, %s, %s, %s)
+            """,
+            (
+                pos_id,
+                norm.get("primary_category"),
+                norm.get("secondary_category"),
+                norm.get("primary_label"),
+                norm.get("secondary_label"),
+                norm.get("confidence"),
+                norm.get("is_data_role", False)
+            )
+        )
+
+        # skill & job_posting_skill 삽입
+        for sk in doc.get("tech_stack", {}).get("raw_list", []):
+            skill_id = upsert_skill(sk)
+            pg_cur.execute(
+                "INSERT INTO job_posting_skill (posting_id, skill_id, skill_type) VALUES (%s, %s, %s) ON CONFLICT DO NOTHING",
+                (posting_id, skill_id, "tech")
+            )
+        for sk in doc.get("preferred_experience", {}).get("raw_list", []):
+            skill_id = upsert_skill(sk)
+            pg_cur.execute(
+                "INSERT INTO job_posting_skill (posting_id, skill_id, skill_type) VALUES (%s, %s, %s) ON CONFLICT DO NOTHING",
+                (posting_id, skill_id, "preferred")
             )
 
         pg_conn.commit()
-        logger.info(f"Processed job_id={doc.get('job_id')} posting_id={posting_id}")
+        logger.info(f"Processed job_id={doc.get('job_id')} → posting_id={posting_id}")
 
     except Exception as e:
         pg_conn.rollback()
-        error_msg = f"Error processing job_id={doc.get('job_id')}: {e}"
-        logger.error(error_msg)
-        log_error(error_msg)
+        err = f"Error processing job_id={doc.get('job_id')}: {e}"
+        logger.error(err)
+        log_error(err)
 
+# --------------------------------------------------
+# 4) ETL 실행
+# --------------------------------------------------
 def run_etl():
     for doc in mdb.job_postings.find({}):
         process_document(doc)

--- a/etl-service/etl-project/requirements.txt
+++ b/etl-service/etl-project/requirements.txt
@@ -1,0 +1,3 @@
+python-dotenv
+pymongo
+psycopg2-binary


### PR DESCRIPTION
## 🔧 Summary

<!-- 간단한 변경 요약 -->

- Postgres 테이블 수정
- env 파일 변수명 수정

## ✅ Changes

<!-- 주요 변경사항 목록 -->

- .env 설정 변경
  * POSTGRES_SERVER → postgres_db
  * MONGO_URI 호스트 → mongo_db
- docker-compose.yml
  * mongo_db/postgres_db에 container_name, restart: always, 환경변수및 포트 매핑(27017, 5432) 추가
  * ETL 서비스(etl)에 depends_on: [mongo_db, postgres_db] 설정 및 command: bash -c "pip install … && python etl.py"로 실행 가능
    하도록 수정
- etl.py 스크립트
  * load_dotenv() 직후 os.environ.pop('PGPASSFILE', None) 추가로 불필요 패스워드 파일 참조 제거
  * MongoClient 초기화에 MONGO_URI 환경변수(mongo_db) 반영
  * psycopg2.connect 호출 시 POSTGRES_SERVER 환경변수(postgres_db) 사용
  * 예외 발생 시 log 테이블에 쌓는 log_error() 함수 구현
- 기술 스택
  * Playwright (동적 콘텐츠 처리)  
  * BeautifulSoup (HTML 파싱)  
  * Requests (HTTP 통신)  
  * PyMongo (MongoDB 연동) 

## 📷 Screenshots (선택사항)

<!-- UI 변경이 있을 경우 첨부 -->

## 📌 Related Issues

Closes #이슈번호